### PR TITLE
Move to Tesseract 4 & LSTM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,49 @@ FROM ubuntu:bionic
 
 MAINTAINER john@deckerego.net
 
+# Install Java and OpenCV
 RUN apt-get --assume-yes update
-RUN apt-get --assume-yes install openjdk-8-jre tesseract-ocr libopencv3.2-jni
+RUN apt-get --assume-yes install openjdk-8-jre libopencv3.2-jni
 
-ARG DOCIDX_VERSION=0.2.0
+# Build chain for Tesseract 4
+RUN apt-get --assume-yes install build-essential git autoconf autoconf-archive wget cmake zlib1g-dev libcairo2-dev libicu-dev libjpeg8-dev libpango1.0-dev libtiff5-dev
+
+# Build Leptonica
+RUN git clone https://github.com/DanBloomberg/leptonica.git
+WORKDIR leptonica
+RUN autoreconf -vi
+RUN ./autobuild
+RUN ./configure
+RUN make
+RUN make install
+WORKDIR ..
+RUN rm -r -f leptonica
+
+# Get Tesseract 4 trained data files
+RUN mkdir /usr/local/share/tessdata
+RUN wget -O /usr/local/share/tessdata/osd.traineddata https://github.com/tesseract-ocr/tessdata/raw/4.00/osd.traineddata
+RUN wget -O /usr/local/share/tessdata/equ.traineddata https://github.com/tesseract-ocr/tessdata/raw/4.00/equ.traineddata
+RUN wget -O /usr/local/share/tessdata/eng.traineddata https://github.com/tesseract-ocr/tessdata/raw/4.00/eng.traineddata
+
+# Build Tesseract 4
+RUN git clone https://github.com/tesseract-ocr/tesseract.git
+WORKDIR tesseract
+RUN ./autogen.sh
+RUN ./configure
+RUN make
+RUN make install
+RUN ldconfig
+RUN make training
+RUN make training-install
+WORKDIR ..
+RUN rm -r -f tesseract
+
+# Clean up Tesseract 4 buildchain
+RUN apt-get --assume-yes remove build-essential git autoconf autoconf-archive wget cmake zlib1g-dev libcairo2-dev libicu-dev libjpeg8-dev libpango1.0-dev libtiff5-dev
+RUN apt-get --assume-yes autoremove
+
+# Install DocIndex
+ARG DOCIDX_VERSION=0.3.0
 ADD target/docidx-${DOCIDX_VERSION}.jar /opt/docidx/docidx.jar
 
 VOLUME /mnt/docs

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,4 +3,4 @@
 OPENCV_NATIVE_LIB='/usr/local/share/OpenCV/java/'
 
 mvn install -DargLine="-Djava.library.path=$OPENCV_NATIVE_LIB"
-[ $? -eq 0 ] && docker build --tag deckerego/docidx:0.2.0 --tag deckerego/docidx:latest .
+[ $? -eq 0 ] && docker build --force-rm --tag deckerego/docidx:0.3.0 --tag deckerego/docidx:snapshot .

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,4 +3,4 @@
 OPENCV_NATIVE_LIB='/usr/local/share/OpenCV/java/'
 
 mvn install -DargLine="-Djava.library.path=$OPENCV_NATIVE_LIB"
-[ $? -eq 0 ] && docker build --force-rm --tag deckerego/docidx:0.3.0 --tag deckerego/docidx:snapshot .
+[ $? -eq 0 ] && docker build --force-rm --tag deckerego/docidx:0.3.2 --tag deckerego/docidx:snapshot .

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>net.deckerego</groupId>
 	<artifactId>docidx</artifactId>
-	<version>0.3.0</version>
+	<version>0.3.2</version>
 	<packaging>jar</packaging>
 
 	<name>DocIndex</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>net.deckerego</groupId>
 	<artifactId>docidx</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0</version>
 	<packaging>jar</packaging>
 
 	<name>DocIndex</name>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 logging.level.net.deckerego.docidx=DEBUG
 
-broker.poolThreads: 4
+broker.poolThreads: 2
 broker.purgeWait: 10000
 broker.timeout: 3600000
 broker.capacity: 10000


### PR DESCRIPTION
Build a container that leverages Tesseract 4 with the new LSTM engine. This requires that Tesseract be built from source, which in turn greatly increases the image size. However - this should result in greater speed and accuracy.